### PR TITLE
Add support for Golang interfaces exposed in Python

### DIFF
--- a/_examples/helloworld/hello.go
+++ b/_examples/helloworld/hello.go
@@ -68,7 +68,14 @@ func (h *Hello) PublicBound(arg1 int) (string, error) {
 
 func (h *Hello) PublicInterface(io io.Reader) (int, error) {
 	bytes := make([]byte, 1024)
-	return io.Read(bytes)
+	n, err := io.Read(bytes)
+	if err != nil {
+		return 0, err
+	}
+
+	fmt.Println(string(bytes[:n]))
+
+	return n, nil
 }
 
 // NewHello constructs a new instance of Hello

--- a/_examples/helloworld/hello.go
+++ b/_examples/helloworld/hello.go
@@ -68,6 +68,7 @@ func (h *Hello) PublicBound(arg1 int) (string, error) {
 
 func (h *Hello) PublicInterface(io io.Reader) (int, error) {
 	bytes := []byte{}
+	fmt.Printf("%v", io)
 	return io.Read(bytes)
 }
 

--- a/_examples/helloworld/hello.go
+++ b/_examples/helloworld/hello.go
@@ -1,6 +1,9 @@
 package helloworld
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+)
 
 var (
 	magicNumber = 0
@@ -61,6 +64,11 @@ func PublicUnboundError(arg1 int) (int, error) {
 // PublicBound returns the meaning of everything
 func (h *Hello) PublicBound(arg1 int) (string, error) {
 	return h.Bar, nil
+}
+
+func (h *Hello) PublicInterface(io io.Reader) (int, error) {
+	bytes := []byte{}
+	return io.Read(bytes)
 }
 
 // NewHello constructs a new instance of Hello

--- a/_examples/helloworld/hello.go
+++ b/_examples/helloworld/hello.go
@@ -78,6 +78,10 @@ func (h *Hello) PublicInterface(io io.Reader) (int, error) {
 	return n, nil
 }
 
+func ListOfHellos() []Hello {
+	return []Hello{{Bar: "Hi Steve!"}, {Bar: "Hi Jane!"}, {Bar: "Hi All!"}}
+}
+
 // NewHello constructs a new instance of Hello
 func NewHelloPtr(world World, foo int, bar string, buzz []string, baz float32) *Hello {
 	return &Hello{

--- a/_examples/helloworld/hello.go
+++ b/_examples/helloworld/hello.go
@@ -67,8 +67,7 @@ func (h *Hello) PublicBound(arg1 int) (string, error) {
 }
 
 func (h *Hello) PublicInterface(io io.Reader) (int, error) {
-	bytes := []byte{}
-	fmt.Printf("%v", io)
+	bytes := make([]byte, 1024)
 	return io.Read(bytes)
 }
 

--- a/bind/binder.go
+++ b/bind/binder.go
@@ -74,8 +74,9 @@ func buildSharedLib(outDir string) error {
 // toCodeFile generates a CGo wrapper around the pkg
 func toCodeFile(pkg *cgo.Package) *ast.File {
 	cImport := cgo.Imports("C")
+
 	cImport.Doc = &ast.CommentGroup{
-		List: cgo.IncludeComments("<stdlib.h>"),
+		List: append(cgo.IncludeComments("<stdlib.h>"), cgo.RawComments(pkg.CDefinitions()...)...),
 	}
 
 	declarations := []ast.Decl{

--- a/bind/python/binder.go
+++ b/bind/python/binder.go
@@ -23,14 +23,16 @@ const (
 )
 
 var (
-	startCGoDefine  = regexp.MustCompile(`^typedef`)
+	startCGoDefine  = regexp.MustCompile(`^typedef|^struct`)
 	sizeOfRemove    = regexp.MustCompile(`_check_for_64_bit_pointer_matching_GoInt`)
 	complexRemove   = regexp.MustCompile(`_Complex`)
 	endif           = regexp.MustCompile(`^#endif`)
+	pounds          = regexp.MustCompile(`^#line|#ifndef|^#define|^#ifdef`)
+	inline          = regexp.MustCompile(`^inline`)
 	endOfCGoDefine  = regexp.MustCompile(`^#ifdef __cplusplus`)
 	extern          = regexp.MustCompile(`^extern \w`)
 	sizeTypeReplace = regexp.MustCompile(`__SIZE_TYPE__`)
-	removeFilters   = []*regexp.Regexp{sizeOfRemove, complexRemove}
+	removeFilters   = []*regexp.Regexp{sizeOfRemove, complexRemove, pounds, inline}
 	replaceFilters  = map[string]*regexp.Regexp{"size_t": sizeTypeReplace}
 	reserved_words  = hashset.New()
 )

--- a/bind/python/binder.go
+++ b/bind/python/binder.go
@@ -188,7 +188,7 @@ func (p Binder) Classes() []*Class {
 }
 
 func (p Binder) Interfaces() []*Interface {
-	interfaces := make([]*Interface, len(p.pkg.Structs()))
+	interfaces := make([]*Interface, len(p.pkg.Interfaces()))
 	for idx, i := range p.pkg.Interfaces() {
 		interfaces[idx] = p.NewInterface(i)
 	}

--- a/bind/python/binder.go
+++ b/bind/python/binder.go
@@ -69,7 +69,7 @@ func NewBinder(pkg *cgo.Package) core.Bindable {
 }
 
 func (p Binder) NewList(slice *cgo.Slice) *List {
-	_, name := slice.ElementPackageAliasAndPath(nil)
+	name := slice.ElementPackageAliasAndPath(nil)
 	sliceType := core.ToCap(name)
 	v := types.NewVar(token.Pos(0), nil, "value", slice.Elem())
 	return &List{
@@ -78,7 +78,7 @@ func (p Binder) NewList(slice *cgo.Slice) *List {
 		InputFormat: func() string {
 			return InputFormat("value", slice.Elem())
 		},
-		OutputFormat: p.NewParam(v).ReturnFormat,
+		OutputFormat: p.NewParam(v).ReturnFormatWithName,
 	}
 }
 

--- a/bind/python/class.go
+++ b/bind/python/class.go
@@ -14,7 +14,7 @@ type Class struct {
 }
 
 func (c Class) Name() string {
-	return c.Struct.Named.Obj().Name()
+	return c.Named.Obj().Name()
 }
 
 func (c Class) MethodName(p *Param) string {

--- a/bind/python/class.go
+++ b/bind/python/class.go
@@ -2,7 +2,6 @@ package python
 
 import (
 	"github.com/devigned/veil/cgo"
-	"go/types"
 )
 
 type Class struct {
@@ -23,11 +22,4 @@ func (c Class) MethodName(p *Param) string {
 
 func (c Class) NewMethodName() string {
 	return c.Struct.NewMethodName()
-}
-
-func (p *Binder) NewParam(v *types.Var) *Param {
-	return &Param{
-		underlying: v,
-		binder:     p,
-	}
 }

--- a/bind/python/func.go
+++ b/bind/python/func.go
@@ -41,22 +41,19 @@ func (f Func) PrintArgs() string {
 
 func (f Func) PrintReturns() string {
 	returns := ""
-	//if f.fun.CName() == "github_com_azure_azure_sdk_for_go_storage_Container_Create" {
-	//	fmt.Println("got here")
-	//}
 	if len(f.Results) > 1 {
 		names := []string{}
 		for i := 0; i < len(f.Results); i++ {
 			result := f.Results[i]
 			if !cgo.ImplementsError(result.underlying.Type()) {
-				names = append(names, result.ReturnFormat(fmt.Sprintf(RETURN_VAR_NAME+".r%d", i)))
+				names = append(names, result.ReturnFormatWithName(fmt.Sprintf(RETURN_VAR_NAME+".r%d", i)))
 			}
 		}
 		returns = strings.Join(names, ", ")
 	} else if len(f.Results) == 1 {
 		if !cgo.ImplementsError(f.Results[0].underlying.Type()) {
 			result := f.Results[0]
-			returns = result.ReturnFormat(RETURN_VAR_NAME)
+			returns = result.ReturnFormatWithName(RETURN_VAR_NAME)
 		}
 	}
 
@@ -75,4 +72,8 @@ func (f Func) ResultsLength() int {
 // IsBound returns true if the function is bound to a named type
 func (f Func) IsBound() bool {
 	return f.fun.BoundRecv == nil
+}
+
+func (f Func) RegistrationName() string {
+	return f.fun.Name()
 }

--- a/bind/python/func.go
+++ b/bind/python/func.go
@@ -64,6 +64,10 @@ func (f Func) PrintReturns() string {
 	}
 }
 
+func (f Func) ParamsLength() int {
+	return len(f.Params)
+}
+
 // ResultsLength returns the length of the results array
 func (f Func) ResultsLength() int {
 	return len(f.Results)

--- a/bind/python/func.go
+++ b/bind/python/func.go
@@ -77,3 +77,11 @@ func (f Func) IsBound() bool {
 func (f Func) RegistrationName() string {
 	return f.fun.Name()
 }
+
+func (f Func) CallbackAttribute() string {
+	voidPtrs := make([]string, f.ResultsLength())
+	for i := 0; i < f.ResultsLength(); i++ {
+		voidPtrs[i] = "void*"
+	}
+	return fmt.Sprintf("@ffi.callback(\"void*(%s)\")", strings.Join(voidPtrs, ", "))
+}

--- a/bind/python/interface.go
+++ b/bind/python/interface.go
@@ -1,0 +1,19 @@
+package python
+
+import (
+	"github.com/devigned/veil/cgo"
+)
+
+type Interface struct {
+	*cgo.Interface
+	binder  *Binder
+	Methods []*Func
+}
+
+func (i Interface) Name() string {
+	return i.Named.Obj().Name()
+}
+
+func (i Interface) NewMethodName() string {
+	return i.NewMethodName()
+}

--- a/bind/python/interface.go
+++ b/bind/python/interface.go
@@ -12,7 +12,11 @@ type Interface struct {
 }
 
 func (iface Interface) Name() string {
-	return iface.Obj().Name()
+	return iface.Interface.Name()
+}
+
+func (iface Interface) CName() string {
+	return iface.Interface.CName()
 }
 
 // ToAst returns the go/ast representation of the CGo wrapper of the named type

--- a/bind/python/interface.go
+++ b/bind/python/interface.go
@@ -2,6 +2,7 @@ package python
 
 import (
 	"github.com/devigned/veil/cgo"
+	"go/ast"
 )
 
 type Interface struct {
@@ -10,10 +11,12 @@ type Interface struct {
 	Methods []*Func
 }
 
-func (i Interface) Name() string {
-	return i.Named.Obj().Name()
+func (iface Interface) Name() string {
+	return iface.Obj().Name()
 }
 
-func (i Interface) NewMethodName() string {
-	return i.NewMethodName()
+// ToAst returns the go/ast representation of the CGo wrapper of the named type
+func (iface Interface) ToAst() []ast.Decl {
+	decls := []ast.Decl{}
+	return decls
 }

--- a/bind/python/list.go
+++ b/bind/python/list.go
@@ -1,12 +1,29 @@
 package python
 
+import (
+	"github.com/devigned/veil/cgo"
+	"strings"
+	"github.com/devigned/veil/core"
+)
+
 type List struct {
-	SliceType    string
+	*cgo.Slice
 	MethodPrefix string
 	InputFormat  func() string
 	OutputFormat func(string) string
 }
 
 func (l List) ListTypeName() string {
-	return l.SliceType + "List"
+	return l.Name() + "List"
+}
+
+func (l List) Name() string {
+	typeString := l.Slice.ElementPackageAliasAndPath(nil)
+	typeString = strings.Replace(typeString, "[]", "SliceOf", -1)
+	splits := strings.Split(typeString, ".")
+	if len(splits) > 1 {
+		return splits[len(splits)-1]
+	} else {
+		return core.ToCap(splits[0])
+	}
 }

--- a/bind/python/list.go
+++ b/bind/python/list.go
@@ -6,3 +6,7 @@ type List struct {
 	InputFormat  func() string
 	OutputFormat func(string) string
 }
+
+func (l List) ListTypeName() string {
+	return l.SliceType + "List"
+}

--- a/bind/python/param.go
+++ b/bind/python/param.go
@@ -5,13 +5,14 @@ import (
 	"github.com/devigned/veil/cgo"
 	"github.com/devigned/veil/core"
 	"go/types"
+	"strconv"
 )
 
 const (
 	STRING_OUTPUT_TRANSFORM = "_CffiHelper.c2py_string(%s)"
 	STRING_INPUT_TRANSFORM  = "%s = _CffiHelper.py2c_string(%s)"
 	STRUCT_INPUT_TRANSFORM  = "%s = _CffiHelper.py2c_veil_object(%s)"
-	STRUCT_OUTPUT_TRANSFORM = "%s(%s)"
+	STRUCT_OUTPUT_TRANSFORM = "%s(uuid_ptr=%s, tracked=%s)"
 )
 
 type Param struct {
@@ -28,10 +29,15 @@ func (p Param) IsError() bool {
 }
 
 func (p Param) ReturnFormatWithName(varName string) string {
-	return p.returnFormatWithTypeAndName(p.underlying.Type(), varName)
+	return p.ReturnFormatWithNameAndTracked(varName, true)
 }
 
-func (p Param) returnFormatWithTypeAndName(typ types.Type, varName string) string {
+func (p Param) ReturnFormatWithNameAndTracked(varName string, tracked bool) string {
+	return p.returnFormatWithTypeAndNameAndTracked(p.underlying.Type(), varName, tracked)
+}
+
+func (p Param) returnFormatWithTypeAndNameAndTracked(typ types.Type, varName string, tracked bool) string {
+	trackedBoolStr := core.ToCap(strconv.FormatBool(tracked))
 	switch t := typ.(type) {
 	case *types.Basic:
 		if t.Kind() == types.String {
@@ -40,18 +46,18 @@ func (p Param) returnFormatWithTypeAndName(typ types.Type, varName string) strin
 		return varName
 	case *types.Named:
 		if cgo.ImplementsError(t) {
-			return fmt.Sprintf(STRUCT_OUTPUT_TRANSFORM, "VeilError", varName)
+			return fmt.Sprintf(STRUCT_OUTPUT_TRANSFORM, "VeilError", varName, trackedBoolStr)
 		} else if _, ok := t.Underlying().(*types.Struct); ok {
 			class := p.binder.NewClass(cgo.NewStruct(t))
-			return fmt.Sprintf(STRUCT_OUTPUT_TRANSFORM, class.Name(), varName)
+			return fmt.Sprintf(STRUCT_OUTPUT_TRANSFORM, class.Name(), varName, trackedBoolStr)
 		} else {
 			return varName
 		}
 	case *types.Slice:
 		slice := p.binder.NewList(cgo.NewSlice(t.Elem()))
-		return fmt.Sprintf(STRUCT_OUTPUT_TRANSFORM, slice.ListTypeName(), varName)
+		return fmt.Sprintf(STRUCT_OUTPUT_TRANSFORM, slice.ListTypeName(), varName, trackedBoolStr)
 	case *types.Pointer:
-		return p.returnFormatWithTypeAndName(t.Elem(), varName)
+		return p.returnFormatWithTypeAndNameAndTracked(t.Elem(), varName, tracked)
 	default:
 		return varName
 	}
@@ -71,6 +77,10 @@ func InputFormat(varName string, typ types.Type) string {
 		}
 	}
 	return ""
+}
+
+func (p Param) ReturnFormatUntracked() string{
+	return p.ReturnFormatWithNameAndTracked(p.Name(), false)
 }
 
 func (p Param) ReturnFormat() string {

--- a/bind/python/param.go
+++ b/bind/python/param.go
@@ -16,12 +16,17 @@ const (
 )
 
 type Param struct {
-	underlying *types.Var
-	binder     *Binder
+	underlying  *types.Var
+	binder      *Binder
+	DefaultName string
 }
 
 func (p Param) Name() string {
-	return core.ToSnake(p.underlying.Name())
+	name := p.DefaultName
+	if p.underlying.Name() != "" {
+		name = p.underlying.Name()
+	}
+	return core.ToSnake(name)
 }
 
 func (p Param) IsError() bool {
@@ -79,7 +84,7 @@ func InputFormat(varName string, typ types.Type) string {
 	return ""
 }
 
-func (p Param) ReturnFormatUntracked() string{
+func (p Param) ReturnFormatUntracked() string {
 	return p.ReturnFormatWithNameAndTracked(p.Name(), false)
 }
 

--- a/bind/python/template.go
+++ b/bind/python/template.go
@@ -259,7 +259,12 @@ def _internal_{{$func.Name}}({{$func.PrintArgs}}, userdata):
 	{{ range $_, $param := $func.Params -}}
 	  {{ printf "%s = %s" $param.Name $param.ReturnFormat }}
 	{{ end -}}
-	{{$cret}} = obj.{{$func.Name}}({{$func.PrintArgs}})
+	ret = obj.{{$func.Name}}({{$func.PrintArgs}})
+	{{$cret}} = ffi.new("ReturnType_2 *")
+	{{$cret}}.r0 = ffi.new("GoInt *", ret[0])
+	{{$cret}}.r1 = ffi.NULL
+	return {{$cret}}
+
 {{end -}}
 class {{$iface.Name}}(VeilObject):
 		def __init__(self, uuid_ptr=None):
@@ -270,6 +275,7 @@ class {{$iface.Name}}(VeilObject):
 			{{range $_, $func := $iface.Methods }}
 			self.__get_method__("register_callback")(self.uuid_ptr(), _CffiHelper.py2c_string("{{$func.RegistrationName}}"), _internal_{{$func.Name}})
 			{{end}}
+
 
 		def __go_type__(self):
 			return "{{$iface.CName}}"

--- a/bind/python/template.go
+++ b/bind/python/template.go
@@ -251,6 +251,8 @@ class {{$class.Name}}(VeilObject):
 
 {{end}}
 
+
+
 `
 )
 

--- a/bind/python/template.go
+++ b/bind/python/template.go
@@ -66,69 +66,71 @@ class _CffiHelper(object):
     		return ffi.NULL
 
 class VeilObject(object):
-    def __init__(self, uuid_ptr):
-        self._uuid_ptr = uuid_ptr
+	def __init__(self, uuid_ptr, tracked=True):
+		self._uuid_ptr = uuid_ptr
+		self._tracked = tracked
 
-    def __del__(self):
-        _CffiHelper.cgo_decref(self._uuid_ptr)
+	def __del__(self):
+		if self._tracked:
+			_CffiHelper.cgo_decref(self._uuid_ptr)
 
-    def go_uuid(self):
+	def go_uuid(self):
     	ba = bytearray(16)
     	ffi.memmove(ba, self._uuid_ptr, 16)
-    	return uuid.UUID(bytes=ba)
+    	return uuid.UUID(bytes=bytes(ba))
 
-    def uuid_ptr(self):
+	def uuid_ptr(self):
         return self._uuid_ptr
 
 
 class VeilList(MutableSequence):
-    def __init__(self, data=None, uuid_ptr=None):
-        if uuid_ptr is None:
-            uuid_ptr = self.__get_method__("new")()
-        self._veil_obj = VeilObject(uuid_ptr)
-        super(VeilList, self).__init__()
+	def __init__(self, data=None, uuid_ptr=None, tracked=True):
+		if uuid_ptr is None:
+			tracked = True
+			uuid_ptr = self.__get_method__("new")()
+		self._veil_obj = VeilObject(uuid_ptr, tracked=tracked)
+		super(VeilList, self).__init__()
 
-
-		@abstractmethod
-    def __go_slice_type__(self):
-        raise NotImplementedError("__go_slice_type__ is not implemented on VeilList and should "
+	@abstractmethod
+	def __go_slice_type__(self):
+		raise NotImplementedError("__go_slice_type__ is not implemented on VeilList and should "
                                   "only be implemented in the inheriting object.")
 
-    def __go_type_input_transform__(self, value):
-    	return value
+	def __go_type_input_transform__(self, value):
+		return value
 
-    def __go_type_output_transform__(self, value):
-    	return value
+	def __go_type_output_transform__(self, value):
+		return value
 
-    def __len__(self):
-        """List length"""
-        return self.__get_method__("len")(self._veil_obj.uuid_ptr())
+	def __len__(self):
+		"""List length"""
+		return self.__get_method__("len")(self._veil_obj.uuid_ptr())
 
-    def __getitem__(self, idx):
-        """Get a list item"""
-        if idx >= self.__len__():
-        	raise IndexError
-        value = self.__get_method__("item")(self._veil_obj.uuid_ptr(), idx)
-        return self.__go_type_output_transform__(value)
+	def __getitem__(self, idx):
+		"""Get a list item"""
+		if idx >= self.__len__():
+			raise IndexError
+		value = self.__get_method__("item")(self._veil_obj.uuid_ptr(), idx)
+		return self.__go_type_output_transform__(value)
 
-    def __delitem__(self, idx):
-        """Delete an item"""
-        self.__get_method__("item_del")(self._veil_obj.uuid_ptr(), idx)
+	def __delitem__(self, idx):
+		"""Delete an item"""
+		self.__get_method__("item_del")(self._veil_obj.uuid_ptr(), idx)
 
-    def __setitem__(self, idx, val):
-    	val = self.__go_type_input_transform__(val)
-    	self.__get_method__("item_set")(self._veil_obj.uuid_ptr(), idx, val)
+	def __setitem__(self, idx, val):
+		val = self.__go_type_input_transform__(val)
+		self.__get_method__("item_set")(self._veil_obj.uuid_ptr(), idx, val)
 
-    def insert(self, idx, val):
-    	val = self.__go_type_input_transform__(val)
-    	self.__get_method__("item_insert")(self._veil_obj.uuid_ptr(), idx, val)
+	def insert(self, idx, val):
+		val = self.__go_type_input_transform__(val)
+		self.__get_method__("item_insert")(self._veil_obj.uuid_ptr(), idx, val)
 
-    def __go_str__(self):
-        cret = self.__get_method__("str")(self._veil_obj.uuid_ptr())
-        return _CffiHelper.c2py_string(cret)
+	def __go_str__(self):
+		cret = self.__get_method__("str")(self._veil_obj.uuid_ptr())
+		return _CffiHelper.c2py_string(cret)
 
-    def __get_method__(self, method_name):
-        return getattr(_CffiHelper.lib, self.__go_slice_type__() + "_" + method_name)
+	def __get_method__(self, method_name):
+		return getattr(_CffiHelper.lib, self.__go_slice_type__() + "_" + method_name)
 
 
 class VeilError(Exception):
@@ -143,8 +145,8 @@ class VeilError(Exception):
 
 {{range $_, $listType := .Lists}}
 class {{$listType.SliceType}}List(VeilList):
-	def __init__(self, data=None, uuid_ptr=None):
-		super({{$listType.SliceType}}List, self).__init__(data=data, uuid_ptr=uuid_ptr)
+	def __init__(self, data=None, uuid_ptr=None, tracked=True):
+		super({{$listType.SliceType}}List, self).__init__(data=data, uuid_ptr=uuid_ptr, tracked=tracked)
 
 	def __go_slice_type__(self):
 		return "{{$listType.MethodPrefix}}"
@@ -179,10 +181,11 @@ def {{$func.Name}}({{$func.PrintArgs}}):
 {{range $_, $class := .Classes}}
 class {{$class.Name}}(VeilObject):
 
-		def __init__(self, uuid_ptr=None):
+		def __init__(self, uuid_ptr=None, tracked=True):
 			if uuid_ptr is None:
 				uuid_ptr = _CffiHelper.lib.{{$class.NewMethodName}}()
-			super({{$class.Name}}, self).__init__(uuid_ptr)
+				tracked = True
+			super({{$class.Name}}, self).__init__(uuid_ptr, tracked=tracked)
 
 		def __go_str__(self):
 			cret = _CffiHelper.lib.{{$class.ToStringMethodName}}(self._uuid_ptr)
@@ -257,11 +260,11 @@ class {{$class.Name}}(VeilObject):
 def _internal_{{$func.Name}}({{$func.PrintArgs}}, userdata):
 	obj = ffi.from_handle(userdata)
 	{{ range $_, $param := $func.Params -}}
-	  {{ printf "%s = %s" $param.Name $param.ReturnFormat }}
+	  {{ printf "%s = %s" $param.Name $param.ReturnFormatUntracked }}
 	{{ end -}}
 	ret = obj.{{$func.Name}}({{$func.PrintArgs}})
 	{{$cret}} = ffi.new("ReturnType_2 *")
-	{{$cret}}.r0 = ffi.new("GoInt *", ret[0])
+	{{$cret}}.r0 = ffi.new("int *", ret[0])
 	{{$cret}}.r1 = ffi.NULL
 	return {{$cret}}
 

--- a/cgo/ast_helpers.go
+++ b/cgo/ast_helpers.go
@@ -48,6 +48,18 @@ var (
 	})
 )
 
+func Panic(message string) ast.Expr {
+	return &ast.CallExpr{
+		Fun: NewIdent("panic"),
+		Args: []ast.Expr{
+			&ast.BasicLit{
+				Kind:  token.STRING,
+				Value: "\"" + message + "\"",
+			},
+		},
+	}
+}
+
 // CObjectStruct produces an AST struct which will represent a C exposed Object
 func CObjectStruct() ast.Decl {
 	return &ast.GenDecl{

--- a/cgo/aster.go
+++ b/cgo/aster.go
@@ -11,8 +11,9 @@ type AstTransformer interface {
 	Exportable
 }
 
-type Packaged interface {
-	PackagePath() string
+type Aliased interface {
+	Alias() string
+	Path() string
 }
 
 type Exportable interface {

--- a/cgo/interface.go
+++ b/cgo/interface.go
@@ -1,7 +1,18 @@
 package cgo
 
 import (
+	"fmt"
+	"go/ast"
+	"go/token"
 	"go/types"
+	"strings"
+)
+
+var (
+	strCFuncPtrMapType = &ast.MapType{
+		Key:   NewIdent("string"),
+		Value: unsafePointer,
+	}
 )
 
 // Inerface is a helpful facade over types.Named which is intended to only contain an Interface
@@ -14,4 +25,221 @@ func NewInterface(named *types.Named) *Interface {
 		panic("only interfaces belong in Interface")
 	}
 	return &Interface{NewNamed(named)}
+}
+
+func (iface Interface) ExportedMethods() []*Func {
+	var methods []*Func
+	underlyingIface := iface.Interface()
+	numMethods := underlyingIface.NumMethods()
+	for i := 0; i < numMethods; i++ {
+		meth := underlyingIface.Method(i)
+		fun := NewBoundFunc(meth, iface.Named)
+		if fun.IsExportable() {
+			methods = append(methods, fun)
+		}
+	}
+	return methods
+}
+
+func (iface Interface) Interface() *types.Interface {
+	return iface.Underlying().(*types.Interface)
+}
+
+// ToAst returns the go/ast representation of the CGo wrapper of the named type
+func (iface Interface) ToAst() []ast.Decl {
+	decls := []ast.Decl{iface.HelperStructAst(), iface.NewAst(), iface.StringAst()}
+	// decls = append(decls, iface.MethodAsts()...)
+	return decls
+}
+
+func (iface Interface) CDefs() (retTypes []string, funcPtrs []string, calls []string) {
+	retTypes = []string{}
+	funcPtrs = []string{}
+	calls = []string{}
+	for _, method := range iface.ExportedMethods() {
+		r, f, c := method.CDefs()
+		if r != "" {
+			retTypes = append(retTypes, r)
+		}
+		funcPtrs = append(funcPtrs, f)
+		calls = append(calls, c)
+	}
+	return retTypes, funcPtrs, calls
+}
+
+func (f Func) CDefs() (retTypes string, funcPtrs string, calls string) {
+	sig := f.Signature()
+	resLen := sig.Results().Len()
+	paramLen := sig.Params().Len()
+	if resLen > 1 {
+		//struct ReturnType_2 { void* r0; void* r1; };
+		//typedef ReturnType_2 FuncPtr_2_2(void *bytes, void *handle);
+		//inline ReturnType_2 CallHandleFunc_2_2(void *bytes, void *handle, FuncPtr_2_2 *fn) { return fn(bytes, handle); }
+		returnTypeDefName := fmt.Sprintf(""+"ReturnType_%d", resLen)
+		returnTypeDef := fmt.Sprintf("//struct %s {%s;};",
+			returnTypeDefName,
+			strings.Join(voidPtrs("r", resLen), "; "))
+
+		funcArgs := strings.Join(voidPtrs("arg", paramLen), ", ")
+		funcPtrDefName := fmt.Sprintf("FuncPtr_%d_%d", resLen, paramLen)
+		funcPtrDef := fmt.Sprintf("//typedef struct %s %s(%s);",
+			returnTypeDefName,
+			funcPtrDefName,
+			funcArgs)
+
+		callHandleFuncDef := fmt.Sprintf("//inline struct %s %s(%s, %s *fn){ return fn(%s); }",
+			returnTypeDefName,
+			f.CallbackFuncName(),
+			funcArgs,
+			funcPtrDefName,
+			strings.Join(argNames("arg", paramLen), ", "))
+
+		return returnTypeDef, funcPtrDef, callHandleFuncDef
+	} else if resLen == 1 {
+		//typedef void FuncPtr_1_2(void *bytes, void *handle);
+		//inline void CallHandleFunc_1_2(void *bytes, void *handle, FuncPtr_1_2 *fn) { return fn(bytes, handle); }
+		funcArgs := strings.Join(voidPtrs("arg", paramLen), ", ")
+		funcPtrDefName := fmt.Sprintf("FuncPtr_%d_%d", resLen, paramLen)
+		funcPtrDef := fmt.Sprintf("//typedef void* %s(%s);",
+			funcPtrDefName,
+			funcArgs)
+
+		callHandleFuncDef := fmt.Sprintf("//inline void* %s(%s, %s *fn){ return fn(%s); }",
+			f.CallbackFuncName(),
+			funcArgs,
+			funcPtrDefName,
+			strings.Join(argNames("arg", paramLen), ", "))
+
+		return "", funcPtrDef, callHandleFuncDef
+	} else {
+		//typedef void FuncPtr_0_2(void *bytes, void *handle);
+		//inline void CallHandleFunc_0_2(void *bytes, void *handle, FuncPtr_0_2 *fn) { return fn(bytes, handle); }
+		funcArgs := strings.Join(voidPtrs("arg", paramLen), ", ")
+		funcPtrDefName := fmt.Sprintf("FuncPtr_%d_%d", resLen, paramLen)
+		funcPtrDef := fmt.Sprintf("//typedef void %s(%s);",
+			funcPtrDefName,
+			funcArgs)
+
+		callHandleFuncDef := fmt.Sprintf("//inline void %s(%s, %s *fn){ return fn(%s); }",
+			f.CallbackFuncName(),
+			funcArgs,
+			funcPtrDefName,
+			strings.Join(argNames("arg", paramLen), ", "))
+
+		return "", funcPtrDef, callHandleFuncDef
+	}
+}
+
+func (f Func) CallbackFuncName() string {
+	sig := f.Signature()
+	return fmt.Sprintf("CallHandleFunc_%d_%d", sig.Results().Len(), sig.Params().Len())
+}
+
+func voidPtrs(prefix string, length int) []string {
+	results := make([]string, length)
+	for i := 0; i < length; i++ {
+		results[i] = fmt.Sprintf("void *%s%d", prefix, i)
+	}
+	return results
+}
+
+func argNames(prefix string, length int) []string {
+	results := make([]string, length)
+	for i := 0; i < length; i++ {
+		results[i] = fmt.Sprintf("%s%d", prefix, i)
+	}
+	return results
+}
+
+// NewAst produces the []ast.Decl to construct a named type and increment it's reference count
+func (iface Interface) NewAst() ast.Decl {
+	functionName := iface.NewMethodName()
+	handleIdent := NewIdent("handle")
+	structInitialization := func(localVar *ast.Ident) []ast.Stmt {
+		return []ast.Stmt{
+			&ast.AssignStmt{
+				Lhs: []ast.Expr{
+					&ast.SelectorExpr{
+						X:   localVar,
+						Sel: handleIdent,
+					},
+				},
+				Tok: token.ASSIGN,
+				Rhs: []ast.Expr{
+					handleIdent,
+				},
+			},
+			&ast.AssignStmt{
+				Lhs: []ast.Expr{
+					&ast.SelectorExpr{
+						X:   localVar,
+						Sel: NewIdent("callbacks"),
+					},
+				},
+				Tok: token.ASSIGN,
+				Rhs: []ast.Expr{
+					&ast.CompositeLit{
+						Type: strCFuncPtrMapType,
+					},
+				},
+			},
+		}
+	}
+
+	params := []*ast.Field{
+		{
+			Names: []*ast.Ident{handleIdent},
+			Type:  unsafePointer,
+		},
+	}
+	return NewAstWithInitialization(functionName, iface.helperStructName(), params, structInitialization)
+}
+
+// StringAst produces the []ast.Decl to provide a string representation of the named type
+func (iface Interface) StringAst() ast.Decl {
+	functionName := iface.ToStringMethodName()
+	return StringAst(functionName, iface.helperStructName())
+}
+
+// CTypeName returns the selector expression for the Named aliased package and type
+func (iface Interface) CTypeName() ast.Expr {
+	pkgPathIdent := NewIdent(PkgPathAliasFromString(iface.Obj().Pkg().Path()))
+	typeIdent := NewIdent(iface.Obj().Name() + "_helper")
+	return &ast.SelectorExpr{
+		X:   pkgPathIdent,
+		Sel: typeIdent,
+	}
+}
+
+func (iface Interface) MethodsAsts() []ast.Decl {
+	return []ast.Decl{}
+}
+
+func (iface Interface) HelperStructAst() ast.Decl {
+	return &ast.GenDecl{
+		Tok: token.TYPE,
+		Specs: []ast.Spec{
+			&ast.TypeSpec{
+				Name: iface.helperStructName(),
+				Type: &ast.StructType{
+					Fields: &ast.FieldList{
+						List: []*ast.Field{
+							{
+								Names: []*ast.Ident{NewIdent("handle")},
+								Type:  unsafePointer,
+							},
+							{
+								Names: []*ast.Ident{NewIdent("callbacks")},
+								Type:  strCFuncPtrMapType,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (iface Interface) helperStructName() *ast.Ident {
+	return NewIdent(iface.CName() + "_helper")
 }

--- a/cgo/interface.go
+++ b/cgo/interface.go
@@ -1,0 +1,17 @@
+package cgo
+
+import (
+	"go/types"
+)
+
+// Inerface is a helpful facade over types.Named which is intended to only contain an Interface
+type Interface struct {
+	*Named
+}
+
+func NewInterface(named *types.Named) *Interface {
+	if _, ok := named.Underlying().(*types.Interface); !ok {
+		panic("only interfaces belong in Interface")
+	}
+	return &Interface{NewNamed(named)}
+}

--- a/cgo/named.go
+++ b/cgo/named.go
@@ -84,11 +84,15 @@ func (n Named) CShortName() string {
 
 // CName returns the fully resolved name to the named type
 func (n Named) CName() string {
-	return strings.Join([]string{PkgPathAliasFromString(n.PackagePath()), n.Obj().Name()}, "_")
+	return strings.Join([]string{n.Alias(), n.Obj().Name()}, "_")
 }
 
-func (n Named) PackagePath() string {
+func (n Named) Path() string {
 	return n.Obj().Pkg().Path()
+}
+
+func (n Named) Alias() string {
+	return PkgPathAliasFromString(n.Path())
 }
 
 func (n Named) ExportName() string {

--- a/cgo/named.go
+++ b/cgo/named.go
@@ -67,7 +67,8 @@ func (n Named) ToStringMethodName() string {
 // Methods returns the list of methods decorated on the named type
 func (n Named) ExportedMethods() []*Func {
 	var methods []*Func
-	for i := 0; i < n.NumMethods(); i++ {
+	numMethods := n.NumMethods()
+	for i := 0; i < numMethods; i++ {
 		meth := n.Method(i)
 		fun := NewBoundFunc(meth, &n)
 		if fun.IsExportable() {

--- a/cgo/package.go
+++ b/cgo/package.go
@@ -107,6 +107,18 @@ func (p Package) Structs() []*Struct {
 	return v
 }
 
+func (p Package) Interfaces() []*Interface {
+	keysValues := p.symbols.Select(func(key, value interface{}) bool {
+		_, ok := value.(*Interface)
+		return ok
+	})
+	v := make([]*Interface, keysValues.Size())
+	for idx, item := range keysValues.Values() {
+		v[idx] = item.(*Interface)
+	}
+	return v
+}
+
 func (p Package) ExportedTypes() []types.Type {
 	values := p.AstTransformers()
 	output := make([]types.Type, len(values))
@@ -185,10 +197,11 @@ func (p Package) addExportedObject(obj interface{}) error {
 		case *types.Basic:
 			// Todo: should this be handled differently?
 		case *types.Interface:
-			// Todo: probably should handle interfaces
+			if !ImplementsError(named) {
+				addExport(NewInterface(named))
+			}
 		case *types.Slice:
-			namedWrapper := NewNamed(named)
-			addExport(namedWrapper)
+			addExport(NewNamed(named))
 		default:
 			return core.NewSystemError("I don't know how to handle named types like: ", obj)
 		}

--- a/cgo/package.go
+++ b/cgo/package.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devigned/veil/core"
 	"github.com/emirpasic/gods/maps"
 	"github.com/emirpasic/gods/maps/treemap"
+	"github.com/emirpasic/gods/sets/treeset"
 	"github.com/marstr/collection"
 	"go/ast"
 	"strings"
@@ -256,6 +257,37 @@ func (p Package) ToAst() []ast.Decl {
 	}
 
 	return decls
+}
+
+func (p Package) CDefinitions() []string {
+	retTypes := []string{}
+	funcPtrs := []string{}
+	calls := []string{}
+	for _, iface := range p.Interfaces() {
+		r, f, c := iface.CDefs()
+		retTypes = append(retTypes, r...)
+		funcPtrs = append(funcPtrs, f...)
+		calls = append(calls, c...)
+	}
+	retTypes = uniqStrings(retTypes...)
+	funcPtrs = uniqStrings(funcPtrs...)
+	calls = uniqStrings(calls...)
+	return append(append(retTypes, funcPtrs...), calls...)
+}
+
+func uniqStrings(items ...string) []string {
+	set := treeset.NewWithStringComparator()
+
+	for _, item := range items {
+		set.Add(item)
+	}
+
+	slice := make([]string, set.Size())
+	for idx, def := range set.Values() {
+		slice[idx] = def.(string)
+	}
+
+	return slice
 }
 
 func (p Package) IsConstructor(f *Func) bool {

--- a/cgo/struct.go
+++ b/cgo/struct.go
@@ -1,7 +1,6 @@
 package cgo
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -27,10 +26,7 @@ func NewStruct(named *types.Named) *Struct {
 
 // Struct returns the underlying struct
 func (s Struct) Struct() *types.Struct {
-	if _, ok := s.Named.Underlying().(*types.Struct); !ok {
-		fmt.Println(s.Named)
-	}
-	return s.Named.Underlying().(*types.Struct)
+	return s.Underlying().(*types.Struct)
 }
 
 // ToAst returns the go/ast representation of the CGo wrapper of the Array type

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -34,7 +34,7 @@ for a Golang package in each of the targets`,
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return NewGenerator(pkgPath, outDir, targets).Execute()
+			return NewGenerator(pkgPath, outDir, libName, targets).Execute()
 		},
 	}
 	supportedTargets = []string{defaultTarget, "java"}
@@ -42,6 +42,7 @@ for a Golang package in each of the targets`,
 	targets []string
 	pkgPath string
 	outDir  string
+	libName string
 )
 
 func init() {
@@ -59,7 +60,7 @@ func init() {
 		"pkg",
 		"p",
 		"",
-		"Path to Golang package to generate bindings (example github.com/devigned/veil/example/helloworld)")
+		"Path to Golang package to generate bindings (example github.com/devigned/veil/_examples/helloworld)")
 
 	generateCmd.Flags().StringVarP(
 		&outDir,
@@ -67,4 +68,11 @@ func init() {
 		"o",
 		path.Join(cwd, "output"),
 		"Output directory to drop generated binding")
+
+	generateCmd.Flags().StringVarP(
+		&libName,
+		"name",
+		"n",
+		"libgen",
+		"Name of the CGo library to be generated in the output directory")
 }

--- a/cmd/generator.go
+++ b/cmd/generator.go
@@ -15,14 +15,16 @@ type Generator struct {
 	PkgPath string
 	OutDir  string
 	Targets []string
+	LibName string
 }
 
 // NewGenerator constructs a new Generator instance
-func NewGenerator(pkgPath string, outDir string, targets []string) *Generator {
+func NewGenerator(pkgPath string, outDir string, libName string, targets []string) *Generator {
 	return &Generator{
 		PkgPath: pkgPath,
 		OutDir:  outDir,
 		Targets: targets,
+		LibName: libName,
 	}
 }
 
@@ -57,7 +59,7 @@ func (g Generator) Execute() error {
 		if err != nil {
 			return err
 		}
-		binder.Bind(outDir)
+		binder.Bind(outDir, g.LibName)
 	}
 
 	return nil

--- a/core/bindable.go
+++ b/core/bindable.go
@@ -1,6 +1,6 @@
 package core
 
 // Bindable is the interface for any object that will create a binding for a golang.Package
-type Bindable interface {
-	Bind(outDir string) error
+type Binder interface {
+	Bind(outDir, libName string) error
 }


### PR DESCRIPTION
## Building Golang interface bindings for a host language w/ FFI

A language binding to Golang would be incomplete without support for Golang Interfaces. Unfortunately, there is no clear way to implement this feature. The options are the following:
- Generate all known concrete types which implement the interface and expose them via VeilObjects in Python
- Generate an interface / abstract class in hosting language and a concrete helper implementation on the Golang side, which has a callback to the hosting language.

The later approach was chosen due to the first being clearly intractable.

To illustrate the approach, I'll use the `io.Reader` as an example. The goal of this implementation is that neither the Golang package, nor the Python developer should need to know anything about FFI / CGo. The implementation should feel idiomatic to the developer in each language.

```golang
/*
Example method which will call into Reader, which actually calls Read on 
veil_io_Reader_helper. This is what would be in the target Golang package.
*/
func (h *Hello) PublicInterface(io io.Reader) (int, error) {
	bytes := make([]byte, 1024)
	n, err := io.Read(bytes)
	if err != nil {
		return 0, err
	}

	fmt.Println(string(bytes[:n]))

	return n, nil
}

/*
Begin CGo section in main.go. Define a C shim to be able to call function pointers 
into the host language. All of the code below here is generated.
*/
//#include <stdlib.h>
//typedef struct ReturnType_2 {void *r0; void *r1; void *empty;} ReturnType_2;
//typedef struct ReturnType_2* FuncPtr_2_1(void *arg0, void *arg1);
//inline struct ReturnType_2* CallHandleFunc_2_1(void *arg0, void *arg1, FuncPtr_2_1 *fn){ return fn(arg0, arg1); }
import (
	"C"
)

/*
Export the Hello bound method method PublicInterface.
*/
//export veil_github_com_devigned_veil__examples_helloworld_Hello_PublicInterface
func veil_github_com_devigned_veil__examples_helloworld_Hello_PublicInterface(self unsafe.Pointer, io unsafe.Pointer) ( int,  unsafe.Pointer) {
	castArg1 := *(*veil_io_Reader_helper)(cgo_get_ref(cgo_get_uuid_from_ptr(io)))
	castSelf := (*veil_github_com_devigned_veil__examples_helloworld.Hello)(cgo_get_ref(cgo_get_uuid_from_ptr(self)))
	r0, r1 := castSelf.PublicInterface(castArg1)
	return r0, C.CBytes(cgo_incref(unsafe.Pointer(&r1)).Bytes())
}

/*
Define a concrete implementation of io.Reader with a handle to the host 
language object and a map of function pointers to callback into Python.
*/
type veil_io_Reader_helper struct {
	handle		unsafe.Pointer
	callbacks	map[string]unsafe.Pointer
}

/*
Expose a constructor method to the host language, so the host can create an 
instance of the helper struct. The handle to the host object is passed into the 
constructor and retained for future callbacks.
*/
//export veil_io_Reader_new
func veil_io_Reader_new(handle unsafe.Pointer) unsafe.Pointer {
	var o veil_io_Reader_helper
	o.handle = handle
	o.callbacks = map[string]unsafe.Pointer{}
	return C.CBytes(cgo_incref(unsafe.Pointer(&o)).Bytes())
}
//export veil_io_Reader_str
func veil_io_Reader_str(self unsafe.Pointer) *C.char {
	return C.CString(fmt.Sprintf("%#v", *(*veil_io_Reader_helper)(cgo_get_ref(cgo_get_uuid_from_ptr(self)))))
}

/*
Expose a method for host language to register callbacks on the interface object.
*/
//export veil_io_Reader_register_callback
func veil_io_Reader_register_callback(self unsafe.Pointer, methodName *C.char, funcPtr unsafe.Pointer) {
	helper := (*veil_io_Reader_helper)(cgo_get_ref(cgo_get_uuid_from_ptr(self)))
	strMethodName := C.GoString(methodName)
	helper.callbacks[strMethodName] = funcPtr
}

/*
Implementation of Read, which translates arguments to C, calls the C function pointer 
to the host language callback, decrement ref counts on arguments, and reconstitute 
C results into Golang results.
*/
func (iface veil_io_Reader_helper) Read(p []byte) (n int, err error) {
	fun, ok := iface.callbacks["Read"]
	if ok {
		arg0 := C.CBytes(cgo_incref(unsafe.Pointer(&p)).Bytes())
		res := C.CallHandleFunc_2_1(arg0, iface.handle, (*C.FuncPtr_2_1)(fun))
		cgo_decref(arg0)
		var r0 int
		if res.r0 == nil {
			panic("result: r0 is nil and must have a value")
		} else {
			r0 = *(*int)(res.r0)
		}
		var r1 error
		if res.r1 == nil {
			r1 = nil
		} else {
			r1 = *(*error)(res.r1)
		}
		return r0, r1
	} else {
		panic("can't find registerd method: Read")
	}
}
```

```python
# Expose a global callback in Python for Golang to callback into upon Read calls.
@ffi.callback("void*(void*, void*)")
def _internal_veil_io_Reader_read(p, userdata):

    obj = ffi.from_handle(userdata)
    p = ByteList(uuid_ptr=p, tracked=False)
    ret = obj.read(p)
    cret = ffi.new("ReturnType_2 *")
    cret.r0 = _CffiHelper.py2c(ret[0])
    cret.r1 = _CffiHelper.py2c(ret[1])
    return cret


# Reader abstract class which handles object lifetime, callback registration and other FFI stuff
class Reader(VeilObject):
    def __init__(self, uuid_ptr=None):
        if uuid_ptr is None:
            self._handle = ffi.new_handle(self)
            uuid_ptr = self.__get_method__("new")(self._handle)
        super(Reader, self).__init__(uuid_ptr)

        self.__get_method__("register_callback")(self.uuid_ptr(), _CffiHelper.py2c_string("Read"),
                                                 _internal_veil_io_Reader_read)

    def __go_type__(self):
        return "veil_io_Reader"

    def __get_method__(self, method_name):
        return getattr(_CffiHelper.lib, self.__go_type__() + "_" + method_name)

    @abstractmethod
    def read(self, p):
        pass

# StringReader implementation of Reader. This is the only Python code the 
# consumer of the library would need to write. Everything else would be generated.
# Note the code here is pythonic and requires no knowledge of Golang or FFI.
class StringReader(generated.Reader):
    def __init__(self, s):
        super(StringReader, self).__init__()
        self.s = s

    def read(self, p):
        utf8_bytes = self.s.encode("utf-8")
        if len(p) < len(utf8_bytes):
            raise Exception("buffer is not large enough")

        for idx, byte in enumerate(utf8_bytes):
            p[idx] = byte

        return len(utf8_bytes), None
```
